### PR TITLE
Add instructions on setting up test database

### DIFF
--- a/docs/localPostgresSetup.md
+++ b/docs/localPostgresSetup.md
@@ -49,7 +49,8 @@ Note the `connection_limit` parameter. This is [recommended by Prisma](https://w
 relational databases in a Serverless context. You should also append this parameter to your production
 `DATABASE_URL` when configuring your deployments.
 
-You should also setup a test database similarly by adding `TEST_DATABASE_URL` to your `.env` file.
+### Local Test DB
+You should also set up a test database similarly by adding `TEST_DATABASE_URL` to your `.env` file.
 ```env
 TEST_DATABASE_URL="postgresql://postgres@localhost:5432/redwoodblog_test?connection_limit=1"
 ```

--- a/docs/localPostgresSetup.md
+++ b/docs/localPostgresSetup.md
@@ -49,6 +49,11 @@ Note the `connection_limit` parameter. This is [recommended by Prisma](https://w
 relational databases in a Serverless context. You should also append this parameter to your production
 `DATABASE_URL` when configuring your deployments.
 
+You should also setup a test database similarly by adding `TEST_DATABASE_URL` to your `.env` file.
+```env
+TEST_DATABASE_URL="postgresql://postgres@localhost:5432/redwoodblog_test?connection_limit=1"
+```
+
 > Note: local postgres server will need manual start/stop -- this is not handled automatically by RW CLI in a manner similar to sqlite
 
 ### Base URL and path


### PR DESCRIPTION
I was getting the following error when ever I ran `yarn rw test`. It would flash briefly before going away.

```
Prisma schema loaded from db/schema.prisma
Error: Schema Parsing P1012

Get config 
error: Error validating datasource `DS`: The URL for datasource `DS` must start with the protocol `postgresql://`.
  -->  schema.prisma:5
   | 
 4 |   provider = "postgresql"
 5 |   url      = env("DATABASE_URL")
   | 

Validation Error Count: 1
```

Searching for `test database` in redwood issues led me to https://github.com/redwoodjs/create-redwood-app/pull/123 so I added that to the documentation.